### PR TITLE
Add networking code to sync the allowFreerCactusPlacing game rule. #2

### DIFF
--- a/src/main/java/github/erb3/fabric/cactusfix/Client.java
+++ b/src/main/java/github/erb3/fabric/cactusfix/Client.java
@@ -1,0 +1,34 @@
+package github.erb3.fabric.cactusfix;
+
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
+import net.minecraft.world.GameRules;
+
+public class Client implements ClientModInitializer {
+
+    @Override
+    public void onInitializeClient() {
+
+        ClientPlayNetworking.registerGlobalReceiver(Main.SYNC_FREER_CACTUS_PLACING, (client, handler, buf, responseSender) -> {
+            client.execute(() -> {
+
+                final boolean value = buf.readBoolean();
+
+                if (client.world != null) {
+
+                    final GameRules rules = client.world.getGameRules();
+
+                    if (rules != null) {
+
+                        final GameRules.BooleanRule rule = rules.get(Main.ALLOW_FREER_CACTUS_PLACING);
+
+                        if (rule != null) {
+
+                            rule.set(value, null);
+                        }
+                    }
+                }
+            });
+        });
+    }
+}

--- a/src/main/java/github/erb3/fabric/cactusfix/Main.java
+++ b/src/main/java/github/erb3/fabric/cactusfix/Main.java
@@ -3,13 +3,21 @@ package github.erb3.fabric.cactusfix;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleFactory;
 import net.fabricmc.fabric.api.gamerule.v1.GameRuleRegistry;
+import net.fabricmc.fabric.api.networking.v1.PacketByteBufs;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.Identifier;
 import net.minecraft.world.GameRules;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class Main implements ModInitializer {
 
-    public static final Logger LOGGER = LoggerFactory.getLogger("cactusfix");
+    public static final String MOD_ID = "cactusfix";
+    public static final Logger LOGGER = LoggerFactory.getLogger(MOD_ID);
+    public static final Identifier SYNC_FREER_CACTUS_PLACING = new Identifier(MOD_ID, "sync_freer_cactus_placing");
 
     public static final GameRules.Key<GameRules.BooleanRule> SHOULD_CACTUS_DAMAGE_ITEMS =
         GameRuleRegistry.register("shouldCactusDamageItems", GameRules.Category.DROPS,
@@ -21,10 +29,17 @@ public class Main implements ModInitializer {
 
     public static final GameRules.Key<GameRules.BooleanRule> ALLOW_FREER_CACTUS_PLACING =
         GameRuleRegistry.register("allowFreerCactusPlacing", GameRules.Category.MISC,
-            GameRuleFactory.createBooleanRule(false));
+            GameRuleFactory.createBooleanRule(false, (server, rule) -> server.getPlayerManager().getPlayerList().forEach(player -> syncFreerCacusRule(player, rule.get()))));
 
     @Override
     public void onInitialize() {
         LOGGER.info("Hello from Cactusfix! Lets get fixing your cactus");
+        ServerPlayConnectionEvents.JOIN.register((handler, sender, server) -> syncFreerCacusRule(handler.player, server.getGameRules().getBoolean(ALLOW_FREER_CACTUS_PLACING)));
+    }
+
+    private static void syncFreerCacusRule(ServerPlayerEntity player, boolean value) {
+        final PacketByteBuf buf = PacketByteBufs.create();
+        buf.writeBoolean(value);
+        ServerPlayNetworking.send(player, SYNC_FREER_CACTUS_PLACING, buf);
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -21,6 +21,9 @@
     "entrypoints": {
         "main": [
             "github.erb3.fabric.cactusfix.Main"
+        ],
+        "client": [
+            "github.erb3.fabric.cactusfix.Client"
         ]
     },
     "mixins": [


### PR DESCRIPTION
This PR adds some networking code to sync the state of `allowFreerCactusPlacing` to clients when players initially connect to the server or whenever the value of the rule is changed. This fixes the swing animation issue described in #2 and also allows the block placement sound to play. The safety checks in the client packet receiver are likely redundant. I chose to be extra safe there because vanilla doesn't really touch game rules on the client and I suspect there may be some edge cases where the values could be null.